### PR TITLE
Fix connect failures for Linux script

### DIFF
--- a/lib/cli-example.sh
+++ b/lib/cli-example.sh
@@ -20,9 +20,9 @@ cd $jmeter_home/bin || return
   --jmeterlogfile $run_log
 
 # check for failures
-failures="$(grep '\!ERROR\!' ${results_file} )"
+failures="$(grep -E "\!ERROR\!|connect failed" ${results_file} )"
 if [ ${#failures} -ge 2 ]; then
-    echo "ERROR: Results file contains failures!"
+    echo "ERROR: Results file contains failures! $failures"
     exit 1
 else
     echo "Success!"


### PR DESCRIPTION
Added "connect failed" as a search for possible errors. Also, mirroring the PowerShell script, the Linux script now reports the failure.